### PR TITLE
chore(spring): 升级Java版本并优化Spring事件异步处理配置

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <flink.version>1.13.6</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
         <iceberg.version>0.13.1</iceberg.version>
@@ -131,13 +131,13 @@
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
-            <version>1.8.5</version>
+            <version>1.9.7</version>
         </dependency>
-        <!--<dependency>-->
-        <!--<groupId>cglib</groupId>-->
-        <!--<artifactId>cglib</artifactId>-->
-        <!--<version>2.2</version>-->
-        <!--</dependency>-->
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib</artifactId>
+            <version>2.2</version>
+        </dependency>
 
 
         <!--mybatis-->
@@ -300,9 +300,9 @@
         </dependency>
 
         <!--<dependency>-->
-            <!--<groupId>org.apache.hive</groupId>-->
-            <!--<artifactId>hive-exec</artifactId>-->
-            <!--<version>3.1.2</version>-->
+        <!--<groupId>org.apache.hive</groupId>-->
+        <!--<artifactId>hive-exec</artifactId>-->
+        <!--<version>3.1.2</version>-->
         <!--</dependency>-->
         <!--flink & iceberg-->
         <dependency>
@@ -324,9 +324,9 @@
             <!--<scope>provided</scope>-->
         </dependency>
         <!--<dependency>-->
-            <!--<groupId>org.apache.hadoop</groupId>-->
-            <!--<artifactId>hadoop-auth</artifactId>-->
-            <!--<version>3.2.2</version>-->
+        <!--<groupId>org.apache.hadoop</groupId>-->
+        <!--<artifactId>hadoop-auth</artifactId>-->
+        <!--<version>3.2.2</version>-->
         <!--</dependency>-->
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -340,9 +340,9 @@
         </dependency>
         <!--flink & hadoop-->
         <!--<dependency>-->
-            <!--<groupId>org.apache.flink</groupId>-->
-            <!--<artifactId>flink-hadoop-compatibility_${scala.binary.version}</artifactId>-->
-            <!--<version>${flink.version}</version>-->
+        <!--<groupId>org.apache.flink</groupId>-->
+        <!--<artifactId>flink-hadoop-compatibility_${scala.binary.version}</artifactId>-->
+        <!--<version>${flink.version}</version>-->
         <!--</dependency>-->
         <!--hbase-->
         <dependency>

--- a/src/main/java/gxj/study/SpringbootActuatorApplication.java
+++ b/src/main/java/gxj/study/SpringbootActuatorApplication.java
@@ -6,9 +6,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
         (scanBasePackages = {"gxj.study"})
+@EnableAsync(proxyTargetClass = false)  // 关键：使用JDK代理
 @EnableAspectJAutoProxy(proxyTargetClass = false)
 @Import(AppConfig.class)
 //关闭nacos注解

--- a/src/main/java/gxj/study/demo/datastruct/hash/PerformanceTest.java
+++ b/src/main/java/gxj/study/demo/datastruct/hash/PerformanceTest.java
@@ -1,7 +1,6 @@
 package gxj.study.demo.datastruct.hash;
 
 import gxj.study.util.FileUtils;
-import jdk.nashorn.internal.ir.debug.ObjectSizeCalculator;
 import org.apache.commons.lang3.StringUtils;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -44,7 +43,7 @@ public class PerformanceTest {
         }
         t2 = System.currentTimeMillis();
         System.out.println("intHashSet cost:" + (t2 - t1));
-        System.out.println("intHashSet memory:" + ObjectSizeCalculator.getObjectSize(zipHash));
+//        System.out.println("intHashSet memory:" + ObjectSizeCalculator.getObjectSize(zipHash));
         System.out.println("intHashSet size:" + zipHash.size());
 
         //基于布隆过滤器的耗时及内存
@@ -54,7 +53,7 @@ public class PerformanceTest {
         }
         t2 = System.currentTimeMillis();
         System.out.println("zipBloomFilter cost:" + (t2 - t1));
-        System.out.println("zipBloomFilter memory:" + ObjectSizeCalculator.getObjectSize(bf));
+//        System.out.println("zipBloomFilter memory:" + ObjectSizeCalculator.getObjectSize(bf));
         System.out.println("zipBloomFilter size:" + bf.size());
 
         //基于自定义简单hash布隆过滤器的耗时及内存
@@ -64,7 +63,7 @@ public class PerformanceTest {
         }
         t2 = System.currentTimeMillis();
         System.out.println("myBloomFilter cost:" + (t2 - t1));
-        System.out.println("myBloomFilter memory:" + ObjectSizeCalculator.getObjectSize(mybf));
+//        System.out.println("myBloomFilter memory:" + ObjectSizeCalculator.getObjectSize(mybf));
         System.out.println("myBloomFilter size:" + mybf.size());
 
 
@@ -76,7 +75,7 @@ public class PerformanceTest {
         }
         t2 = System.currentTimeMillis();
         System.out.println("RoaringBitMap cost:" + (t2 - t1));
-        System.out.println("RoaringBitMap memory:" + ObjectSizeCalculator.getObjectSize(bm));
+//        System.out.println("RoaringBitMap memory:" + ObjectSizeCalculator.getObjectSize(bm));
         System.out.println("RoaringBitMap size:" + bm.size());
 
 
@@ -89,7 +88,7 @@ public class PerformanceTest {
         t2 = System.currentTimeMillis();
         System.out.println("连续数");
         System.out.println("RoaringBitMap cost:" + (t2 - t1));
-        System.out.println("RoaringBitMap memory:" + ObjectSizeCalculator.getObjectSize(m));
+//        System.out.println("RoaringBitMap memory:" + ObjectSizeCalculator.getObjectSize(m));
 
         //基于hashMap的化简版hash过滤器的耗时及内存
         t1 = System.currentTimeMillis();
@@ -99,7 +98,7 @@ public class PerformanceTest {
         }
         t2 = System.currentTimeMillis();
         System.out.println("HashFilter cost:" + (t2 - t1));
-        System.out.println("HashFilter memory:" + ObjectSizeCalculator.getObjectSize(m));
+//        System.out.println("HashFilter memory:" + ObjectSizeCalculator.getObjectSize(m));
         System.out.println("HashFilter size:" + hf.size());
     }
 

--- a/src/main/java/gxj/study/demo/springevent/MyListener1.java
+++ b/src/main/java/gxj/study/demo/springevent/MyListener1.java
@@ -14,6 +14,6 @@ public class MyListener1 implements ApplicationListener<MyEvent> {
 
     @Override
     public void onApplicationEvent(MyEvent event) {
-        System.out.println("MyListener1: 监听 MyEvent事件 | event:" + event);
+        System.out.println(Thread.currentThread().getName() + ": MyListener1: 监听 MyEvent事件 | event:" + event);
     }
 }

--- a/src/main/java/gxj/study/demo/springevent/MyListener2.java
+++ b/src/main/java/gxj/study/demo/springevent/MyListener2.java
@@ -1,6 +1,7 @@
 package gxj.study.demo.springevent;
 
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 /**
@@ -9,10 +10,10 @@ import org.springframework.stereotype.Component;
  * @description
  */
 @Component
-public class MyListener2 implements ApplicationListener<MyEvent> {
+public class MyListener2 {
 
-    @Override
+    @EventListener
     public void onApplicationEvent(MyEvent event) {
-        System.out.println("MyListener2: 监听 MyEvent事件 | event:" + event);
+        System.out.println(Thread.currentThread().getName()+": MyListener2: 监听 MyEvent事件 | event:" + event);
     }
 }

--- a/src/main/java/gxj/study/demo/springevent/MyListenerAll.java
+++ b/src/main/java/gxj/study/demo/springevent/MyListenerAll.java
@@ -11,8 +11,9 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class MyListenerAll implements ApplicationListener {
+
     @Override
     public void onApplicationEvent(ApplicationEvent event) {
-        System.out.println("MyListenerAll: 监听所有事件 | event:" + event);
+        System.out.println(Thread.currentThread().getName()+": MyListenerAll: 监听所有事件 | event:" + event);
     }
 }

--- a/src/main/java/gxj/study/demo/springevent/MyService.java
+++ b/src/main/java/gxj/study/demo/springevent/MyService.java
@@ -1,6 +1,5 @@
 package gxj.study.demo.springevent;
 
-import gxj.study.demo.spring.bean.MyBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
@@ -16,15 +15,15 @@ public class MyService {
     ApplicationContext applicationContext;
 
     public void doSomething() {
-        System.out.println("do something 第一步");
+        System.out.println(Thread.currentThread().getName() + ": do something 第一步");
         //发布MyEvent事件
-        System.out.println("发布MyEvent事件");
+        System.out.println(Thread.currentThread().getName() + ": 发布MyEvent事件");
         applicationContext.publishEvent(new MyEvent(applicationContext));
 
         //发布MyEvent2事件
-        System.out.println("发布MyEvent2事件");
+        System.out.println(Thread.currentThread().getName() + ": 发布MyEvent2事件");
         applicationContext.publishEvent(new MyEvent2(applicationContext));
 
-
+        System.out.println(Thread.currentThread().getName() + ": 工作流完成！！！");
     }
 }

--- a/src/main/java/gxj/study/demo/springevent/readme.md
+++ b/src/main/java/gxj/study/demo/springevent/readme.md
@@ -1,0 +1,114 @@
+# Spring Application Event 功能介绍
+
+## 概述
+
+Spring Application Event 是 Spring 框架提供的事件驱动编程模型，它基于观察者模式实现应用程序内部的松耦合通信。通过事件发布和监听机制，可以在不直接依赖的情况下实现组件间的通信。
+
+## 核心组件
+
+### 1. 事件 (Event)
+- 继承 `ApplicationEvent` 类
+- 封装事件相关信息
+- 本示例中的 `MyEvent` 和 `MyEvent2` 类
+
+### 2. 事件监听器 (Listener)
+- 实现 `ApplicationListener` 接口或使用 `@EventListener` 注解
+- 监听特定类型的事件
+- 本示例中的 `MyListener1`、 和 `MyListenerAll` 类展示了使用了接口实现;`MyListener2`使用了注解实现。
+
+### 3. 事件发布器 (Publisher)
+- 通过 `ApplicationEventPublisher` 发布事件
+- 本示例中的 `MyService` 类
+
+## 示例结构
+
+本示例包含以下组件：
+
+### 事件类
+- `MyEvent.java` - 自定义事件类1
+- `MyEvent2.java` - 自定义事件类2
+
+### 监听器类
+- `MyListener1.java` - 监听特定事件的监听器
+- `MyListener2.java` - 监听另一个特定事件的监听器
+- `MyListenerAll.java` - 监听所有事件的通用监听器
+
+### 服务类
+- `MyService.java` - 事件发布服务，通过Spring容器发布事件
+
+## 使用方法
+
+### 1. 定义事件
+```java
+public class MyEvent extends ApplicationEvent {
+    private String message;
+    
+    public MyEvent(Object source, String message) {
+        super(source);
+        this.message = message;
+    }
+    
+    // getter methods
+}
+```
+
+### 2. 创建监听器
+```java
+@Component
+public class MyListener1 {
+    @EventListener
+    public void handleMyEvent(MyEvent event) {
+        System.out.println("Received MyEvent: " + event.getMessage());
+    }
+}
+```
+
+### 3. 发布事件
+```java
+@Service
+public class MyService {
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+    
+    public void publishEvent() {
+        MyEvent event = new MyEvent(this, "Hello Event!");
+        eventPublisher.publishEvent(event);
+    }
+}
+```
+
+## 特性
+
+### 同步执行
+默认情况下，事件监听器是同步执行的，事件发布者会等待所有监听器处理完成。
+
+### 异步执行
+可以通过 `@Async` 注解实现异步事件处理，提高系统性能。
+
+### 条件监听
+使用 `@EventListener(condition = "...")` 实现条件事件监听。
+
+## 应用场景
+
+1. **用户注册通知** - 注册成功后发送邮件或短信
+2. **日志记录** - 记录系统操作日志
+3. **缓存更新** - 数据变更时更新缓存
+4. **业务流程解耦** - 实现业务逻辑的松耦合
+
+## 优势
+
+- **松耦合** - 事件发布者和监听者之间无直接依赖
+- **可扩展性** - 可以轻松添加新的事件监听器
+- **灵活性** - 支持同步和异步处理模式
+- **Spring集成** - 与Spring框架无缝集成
+
+## 注意事项
+
+1. 事件监听器方法的参数必须是事件类型的子类
+2. 异步事件处理需要配置 `@EnableAsync` 和任务执行器
+3. 避免在事件处理中出现循环依赖
+4. 注意事件处理的异常处理机制
+
+## 总结
+
+Spring Application Event 提供了一种优雅的解耦方式，使得应用程序组件之间的通信更加灵活。通过事件驱动模型，可以构建更加模块化和可维护的应用程序。

--- a/src/main/java/gxj/study/demo/springevnet2/BaseBiz.java
+++ b/src/main/java/gxj/study/demo/springevnet2/BaseBiz.java
@@ -1,0 +1,10 @@
+package gxj.study.demo.springevnet2;
+
+/**
+ *
+ * @author xinjie_guo
+ * @version 0.1.0
+ * @since 2025/12/25 18:15 0.1.0
+ */
+public interface BaseBiz {
+}

--- a/src/main/java/gxj/study/demo/springevnet2/DeliverBiz.java
+++ b/src/main/java/gxj/study/demo/springevnet2/DeliverBiz.java
@@ -1,0 +1,13 @@
+package gxj.study.demo.springevnet2;
+
+import org.springframework.stereotype.Component;
+
+/**
+ *
+ * @author xinjie_guo
+ * @version 0.1.0
+ * @since 2025/12/25 18:09 0.1.0
+ */
+@Component
+public class DeliverBiz {
+}

--- a/src/main/java/gxj/study/demo/springevnet2/DeliverListener.java
+++ b/src/main/java/gxj/study/demo/springevnet2/DeliverListener.java
@@ -1,0 +1,31 @@
+package gxj.study.demo.springevnet2;
+
+import gxj.study.demo.springevnet2.model.OrderDto;
+import gxj.study.demo.springevnet2.model.OrderEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+/**
+ *
+ * @author xinjie_guo
+ * @version 0.1.0
+ * @since 2025/12/25 17:20 0.1.0
+ */
+//@Component
+@Slf4j
+public class DeliverListener {
+    public DeliverListener() {
+        super(); // 显式调用父类构造函数
+    }
+
+    @EventListener(classes = {OrderEvent.class})
+    @Async
+    @Order(4)
+    public void onApplicationEvent(OrderEvent event) {
+        log.info("[{}] 订单[{}] - 仓库发货", Thread.currentThread().getName(), ((OrderDto) event.getSource()).getOrderNo());
+    }
+
+}

--- a/src/main/java/gxj/study/demo/springevnet2/DeliverSFBiz.java
+++ b/src/main/java/gxj/study/demo/springevnet2/DeliverSFBiz.java
@@ -1,0 +1,13 @@
+package gxj.study.demo.springevnet2;
+
+import org.springframework.stereotype.Component;
+
+/**
+ *
+ * @author xinjie_guo
+ * @version 0.1.0
+ * @since 2025/12/25 18:09 0.1.0
+ */
+@Component
+public class DeliverSFBiz {
+}

--- a/src/main/java/gxj/study/demo/springevnet2/DeliverSFListener.java
+++ b/src/main/java/gxj/study/demo/springevnet2/DeliverSFListener.java
@@ -1,0 +1,32 @@
+package gxj.study.demo.springevnet2;
+
+import gxj.study.demo.springevnet2.model.OrderDto;
+import gxj.study.demo.springevnet2.model.OrderEvent;
+import gxj.study.demo.springevnet2.model.SFOrderEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+/**
+ *
+ * @author xinjie_guo
+ * @version 0.1.0
+ * @since 2025/12/25 17:20 0.1.0
+ */
+//@Component
+@Slf4j
+public class DeliverSFListener {
+
+    public DeliverSFListener() {
+    }
+
+    @EventListener(classes =  {SFOrderEvent.class})
+    @Async
+    @Order(3)
+    public void onApplicationEvent(OrderEvent event) {
+        log.info("[{}] 订单[{}] - 仓库发货SF", Thread.currentThread().getName(), ((OrderDto) event.getSource()).getOrderNo());
+    }
+
+}

--- a/src/main/java/gxj/study/demo/springevnet2/EnvConfig.java
+++ b/src/main/java/gxj/study/demo/springevnet2/EnvConfig.java
@@ -1,0 +1,15 @@
+package gxj.study.demo.springevnet2;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+/**
+ *
+ * @author xinjie_guo
+ * @version 0.1.0
+ * @since 2025/12/25 17:21 0.1.0
+ */
+@EnableAsync(proxyTargetClass = false)  // 关键：使用JDK代理
+@Configuration
+public class EnvConfig {
+}

--- a/src/main/java/gxj/study/demo/springevnet2/OrderListener.java
+++ b/src/main/java/gxj/study/demo/springevnet2/OrderListener.java
@@ -1,0 +1,45 @@
+package gxj.study.demo.springevnet2;
+
+import gxj.study.demo.springevnet2.model.OrderDto;
+import gxj.study.demo.springevnet2.model.OrderEvent;
+import gxj.study.demo.springevnet2.model.SFOrderEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ *
+ * @author xinjie_guo
+ * @version 0.1.0
+ * @since 2025/12/25 18:08 0.1.0
+ */
+@Slf4j
+@Component
+public class OrderListener {
+
+
+    private VipBiz vipBiz;
+
+    @EventListener(classes = {OrderEvent.class})
+    @Order(1)
+    public void onEvent1(OrderEvent event) {
+        vipBiz.execute(((OrderDto) event.getSource()));
+        log.info("[{}] 订单[{}] - 仓库发货", Thread.currentThread().getName(), ((OrderDto) event.getSource()).getOrderNo());
+    }
+
+
+    @EventListener(classes = {OrderEvent.class})
+    @Order(2)
+    public void onEvent2(OrderEvent event) {
+        log.info("[{}] 订单[{}] - 仓库发货", Thread.currentThread().getName(), ((OrderDto) event.getSource()).getOrderNo());
+    }
+
+    @EventListener(classes = {SFOrderEvent.class})
+    @Order(3)
+    public void onEvent3(OrderEvent event) {
+        log.info("[{}] 订单[{}] - 仓库发货SF", Thread.currentThread().getName(), ((OrderDto) event.getSource()).getOrderNo());
+    }
+
+
+}

--- a/src/main/java/gxj/study/demo/springevnet2/OrderService.java
+++ b/src/main/java/gxj/study/demo/springevnet2/OrderService.java
@@ -1,0 +1,37 @@
+package gxj.study.demo.springevnet2;
+
+import gxj.study.demo.springevnet2.model.OrderDto;
+import gxj.study.demo.springevnet2.model.OrderEvent;
+import gxj.study.demo.springevnet2.model.SFOrderEvent;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+/**
+ *
+ * @author xinjie_guo
+ * @version 0.1.0
+ * @since 2025/12/25 16:59 0.1.0
+ */
+@Service
+@AllArgsConstructor
+@Slf4j
+public class OrderService {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void order(OrderDto order) {
+        log.info("[{}] 收到订单[{}]", Thread.currentThread().getName(), order.getOrderNo());
+        eventPublisher.publishEvent(new OrderEvent(order));
+        log.info("[{}] 下单结束！！！", Thread.currentThread().getName());
+    }
+
+
+    public void orderSF(OrderDto order) {
+        log.info("[{}] 收到SF订单[{}]", Thread.currentThread().getName(), order.getOrderNo());
+        eventPublisher.publishEvent(new SFOrderEvent(order));
+        log.info("[{}] SF下单结束！！！", Thread.currentThread().getName());
+    }
+}

--- a/src/main/java/gxj/study/demo/springevnet2/VipBiz.java
+++ b/src/main/java/gxj/study/demo/springevnet2/VipBiz.java
@@ -1,0 +1,22 @@
+package gxj.study.demo.springevnet2;
+
+import gxj.study.demo.springevnet2.model.OrderDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+/**
+ *
+ * @author xinjie_guo
+ * @version 0.1.0
+ * @since 2025/12/25 18:09 0.1.0
+ */
+@Slf4j
+@Component
+public class VipBiz implements BaseBiz {
+
+    @Async
+    public void execute(OrderDto dto) {
+        log.info("[{}] 订单[{}] - vip客户赠送小礼品", Thread.currentThread().getName(), dto.getOrderNo());
+    }
+}

--- a/src/main/java/gxj/study/demo/springevnet2/VipListener.java
+++ b/src/main/java/gxj/study/demo/springevnet2/VipListener.java
@@ -1,0 +1,31 @@
+package gxj.study.demo.springevnet2;
+
+import gxj.study.demo.springevnet2.model.OrderDto;
+import gxj.study.demo.springevnet2.model.OrderEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+/**
+ *
+ * @author xinjie_guo
+ * @version 0.1.0
+ * @since 2025/12/25 17:20 0.1.0
+ */
+//@Component
+@Slf4j
+public class VipListener {
+
+    public VipListener() {
+    }
+
+    @EventListener(condition = "#event.source.vip == true")
+    @Async
+    @Order(1)
+    public void onApplicationEvent(OrderEvent event) {
+        log.info("[{}] 订单[{}] - vip客户赠送小礼品", Thread.currentThread().getName(), ((OrderDto) event.getSource()).getOrderNo());
+    }
+
+}

--- a/src/main/java/gxj/study/demo/springevnet2/model/OrderDto.java
+++ b/src/main/java/gxj/study/demo/springevnet2/model/OrderDto.java
@@ -1,0 +1,27 @@
+package gxj.study.demo.springevnet2.model;
+
+import lombok.Getter;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ *
+ * @author xinjie_guo
+ * @version 0.1.0
+ * @since 2025/12/25 17:05 0.1.0
+ */
+@Getter
+public class OrderDto {
+
+    private static final AtomicInteger atomicInteger = new AtomicInteger(1000);
+
+    private final Integer orderNo;
+    private final String goodsName;
+    private final boolean vip;
+
+    public OrderDto(String goodsName, boolean vip) {
+        this.orderNo = atomicInteger.getAndIncrement();
+        this.goodsName = goodsName;
+        this.vip = vip;
+    }
+}

--- a/src/main/java/gxj/study/demo/springevnet2/model/OrderEvent.java
+++ b/src/main/java/gxj/study/demo/springevnet2/model/OrderEvent.java
@@ -1,0 +1,18 @@
+package gxj.study.demo.springevnet2.model;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ *
+ * @author xinjie_guo
+ * @version 0.1.0
+ * @since 2025/12/25 17:05 0.1.0
+ */
+@Getter
+public class OrderEvent extends ApplicationEvent {
+
+    public OrderEvent(OrderDto order) {
+        super(order);
+    }
+}

--- a/src/main/java/gxj/study/demo/springevnet2/model/SFOrderEvent.java
+++ b/src/main/java/gxj/study/demo/springevnet2/model/SFOrderEvent.java
@@ -1,0 +1,18 @@
+package gxj.study.demo.springevnet2.model;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ *
+ * @author xinjie_guo
+ * @version 0.1.0
+ * @since 2025/12/25 17:05 0.1.0
+ */
+@Getter
+public class SFOrderEvent extends OrderEvent {
+
+    public SFOrderEvent(OrderDto order) {
+        super(order);
+    }
+}

--- a/src/main/java/gxj/study/util/FileUtils.java
+++ b/src/main/java/gxj/study/util/FileUtils.java
@@ -1,13 +1,7 @@
 package gxj.study.util;
 
-import gxj.study.demo.datastruct.hash.ZipBloomFilter;
-import gxj.study.demo.datastruct.hash.ZipHash;
-import jdk.nashorn.internal.ir.debug.ObjectSizeCalculator;
-import org.apache.commons.lang3.StringUtils;
-
 import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.util.HashSet;
 import java.util.Scanner;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;

--- a/src/main/java/gxj/study/util/encrypt/ThreeDesUtil.java
+++ b/src/main/java/gxj/study/util/encrypt/ThreeDesUtil.java
@@ -1,7 +1,6 @@
 package gxj.study.util.encrypt;
 
 import com.alibaba.dubbo.common.utils.StringUtils;
-import com.sun.org.apache.xerces.internal.impl.dv.util.Base64;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
@@ -13,6 +12,7 @@ import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.lang.invoke.SerializedLambda;
 import java.lang.reflect.Method;
+import java.util.Base64;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -58,12 +58,12 @@ public class ThreeDesUtil {
      */
     public static byte[] encryptMode(byte[] keybyte, byte[] src) {
         try {
-            // 生成密钥 
+            // 生成密钥
             SecretKey deskey = new SecretKeySpec(keybyte, Algorithm);
-            // 加密  
+            // 加密
             Cipher c1 = Cipher.getInstance(Algorithm);
             c1.init(Cipher.ENCRYPT_MODE, deskey);
-            return c1.doFinal(src);// 在单一方面的加密或解密 
+            return c1.doFinal(src);// 在单一方面的加密或解密
         } catch (java.security.NoSuchAlgorithmException e1) {
             log.error("encryptMode error", e1);
         } catch (javax.crypto.NoSuchPaddingException e2) {
@@ -131,7 +131,7 @@ public class ThreeDesUtil {
      * @return String
      */
     public static String doEncrypt(String src,String key) {
-        return Base64.encode(encryptMode(key.getBytes(), src.getBytes()));
+        return Base64.getEncoder().encodeToString(encryptMode(key.getBytes(), src.getBytes()));
     }
 
     /**
@@ -147,7 +147,7 @@ public class ThreeDesUtil {
         }
         byte[] decryptMode = new byte[0];
         try {
-            decryptMode = decryptMode(key.getBytes("UTF-8"), Base64.decode(src));
+            decryptMode = decryptMode(key.getBytes("UTF-8"), Base64.getDecoder().decode(src));
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
         }
@@ -171,7 +171,7 @@ public class ThreeDesUtil {
         if (StringUtils.isEmpty(src)) {
             return src;
         }
-        return Base64.encode(encryptMode(secKey.getBytes(), src.getBytes()));
+        return Base64.getEncoder().encodeToString(encryptMode(secKey.getBytes(), src.getBytes()));
     }
 
     /**
@@ -222,7 +222,7 @@ public class ThreeDesUtil {
         if (StringUtils.isEmpty(src)) {
             return src;
         }
-        byte[] mode = decryptMode(key.getBytes(), Base64.decode(src));
+        byte[] mode = decryptMode(key.getBytes(), Base64.getDecoder().decode(src));
         if (mode == null) {
             log.error("ERROR checkEncrypt PARAM: {}", doEncrypt(key,src));
             throw new RuntimeException("数据未加密");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,5 +32,3 @@ nacos.config.namespace=127.0.0.1:8848
 #nacosע�����ĵ�ַ
 nacos.discovery.server-addr=127.0.0.1:8848
 
-
-

--- a/src/test/java/gxj/study/demo/springevent/MyServiceTest.java
+++ b/src/test/java/gxj/study/demo/springevent/MyServiceTest.java
@@ -1,22 +1,27 @@
 package gxj.study.demo.springevent;
 
-import gxj.study.BaseTest;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-import static org.junit.Assert.*;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * Created by xinjie_guo on 2019/11/29.
  */
-public class MyServiceTest extends BaseTest{
+@ComponentScan(basePackages = {
+        "gxj.study.demo.springevent"
+})
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = MyServiceTest.class)
+public class MyServiceTest {
 
     @Autowired
     MyService service;
 
     @Test
-    public void  test(){
+    public void test() {
         service.doSomething();
     }
 

--- a/src/test/java/gxj/study/demo/springevnet2/OrderServiceTest.java
+++ b/src/test/java/gxj/study/demo/springevnet2/OrderServiceTest.java
@@ -1,0 +1,34 @@
+package gxj.study.demo.springevnet2;
+
+import gxj.study.demo.springevnet2.model.OrderDto;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ *
+ * @author xinjie_guo
+ * @version 0.1.0
+ * @since 2025/12/25 17:29 0.1.0
+ */
+@ComponentScan(basePackages = {
+        "gxj.study.demo.springevnet2"
+})
+@EnableAsync(proxyTargetClass = false)  // 关键：使用JDK代理
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = OrderServiceTest.class)
+public class OrderServiceTest  {
+    @Autowired
+    OrderService orderService;
+
+    @Test
+    public void test() {
+        orderService.order(new OrderDto("咖啡", false));
+        orderService.order(new OrderDto("海鲜", true));
+    }
+
+}


### PR DESCRIPTION
- pom.xml中Java版本从1.8升级到11，AspectJ Weaver依赖版本更新至1.9.7
- 启用cglib依赖，调整依赖注释格式
- SpringbootActuatorApplication中启用@EnableAsync注解，配置使用JDK代理实现异步处理
- Spring事件监听器中添加线程名打印日志，增强调试信息
- MyListener2由实现ApplicationListener接口改用@EventListener注解实现事件监听
- MyService发布事件时添加线程名输出，展示异步调用效果
- 新增springevnet2包，示例Spring异步事件驱动模型，包含事件发布、监听及业务处理组件
- ThreeDesUtil更新Base64编码解码方式，使用Java标准库Base64替代旧API
- 测试代码中补充Spring测试配置，支持异步事件驱动功能测试
- 移除无用导入和注释代码，清理代码结构，提升代码规范性和可维护性